### PR TITLE
Hot-fix NB-134 space typo

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v3
       # The BuildKit Cache
       - name: Step 2 - Set up Docker Buildx
-        uses: docker/setup-buildx-action @v2
+        uses: docker/setup-buildx-action@v2
       # If push and to master, then build the image and run it with npm run npm-publish
       - name: Step 3 - Build Image and Export to Docker Engine
         uses: docker/build-push-action@v2


### PR DESCRIPTION
There was an empty space in action version that caused workflow not to pickup the action